### PR TITLE
Fix #14 adding Multiline Suppor

### DIFF
--- a/custom_components/whatsapper/notify.py
+++ b/custom_components/whatsapper/notify.py
@@ -58,7 +58,7 @@ class WhatsapperNotificationService(BaseNotificationService):
             if data is None:
                 # send the message
                 url = f'http://{self.host_port}/command'
-                body = {"command":"sendMessage", "params":[self.chat_id, message]}
+                body = {"command":"sendMessage", "params":[self.chat_id, message.replace("\\n", "\n")]}
                 resp = requests.post(url, json = body)
 
             # Send an image


### PR DESCRIPTION
Fixes #14

Due to HA limitations that do not allow altering the UI of notify actions (formerly services), it became necessary to allow the code to handle `\n` escapes, which were previously automatically counter-escaped with `\\n`.