### PR TITLE
Enhance message sending by including title (depend on #15)

### DIFF
--- a/custom_components/whatsapper/notify.py
+++ b/custom_components/whatsapper/notify.py
@@ -11,6 +11,8 @@ from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
     BaseNotificationService,
     ATTR_DATA,
+    ATTR_TITLE,
+    ATTR_MESSAGE,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
@@ -58,7 +60,16 @@ class WhatsapperNotificationService(BaseNotificationService):
             if data is None:
                 # send the message
                 url = f'http://{self.host_port}/command'
-                body = {"command":"sendMessage", "params":[self.chat_id, message.replace("\\n", "\n")]}
+                if ATTR_TITLE in kwargs:
+                    title = kwargs.get(ATTR_TITLE)
+                    # Unescape any escaped newlines in message and title
+                    if title is not None:
+                        msg = f"{title}\n\n{message}"
+                    else:
+                        msg = message
+                    # Replace literal backslash-n with real newlines
+                    msg = msg.replace("\\n", "\n")
+                    body = {"command": "sendMessage", "params": [self.chat_id, msg]}
                 resp = requests.post(url, json = body)
 
             # Send an image

--- a/custom_components/whatsapper/notify.py
+++ b/custom_components/whatsapper/notify.py
@@ -58,7 +58,7 @@ class WhatsapperNotificationService(BaseNotificationService):
             if data is None:
                 # send the message
                 url = f'http://{self.host_port}/command'
-                body = {"command":"sendMessage", "params":[self.chat_id, message]}
+                body = {"command":"sendMessage", "params":[self.chat_id, message.replace("\\n", "\n")]}
                 resp = requests.post(url, json = body)
 
             # Send an image


### PR DESCRIPTION
Extends the changes made in PR #15 to add support for the title field of the notify action (formerly service), essentially formatting the message according to the following pattern: 
```
title

message
```