### PR TITLE
Lookup group names + Async support

### DIFF
--- a/custom_components/whatsapper/notify.py
+++ b/custom_components/whatsapper/notify.py
@@ -1,13 +1,12 @@
 """Whatsapper platform for notify component."""
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime, timedelta
 from html.parser import HTMLParser
 
 import voluptuous as vol
-
-import requests
 
 from homeassistant.components.notify import (
     PLATFORM_SCHEMA,
@@ -19,6 +18,7 @@ from homeassistant.components.notify import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,6 +40,7 @@ class ChatListParser(HTMLParser):
     
     Parses format: "Chat Name: chat_id@domain"
     Example: "Purple Tentacle: 31612345678@c.us"
+         and "Take Over the World Taskforce: 31612345678-0987654321@g.us"
     Handles chat names containing colons.
     """
 
@@ -72,7 +73,7 @@ class ChatListParser(HTMLParser):
             
             # Validate chat_id format (should contain @ symbol)
             if chat_id and "@" in chat_id and chat_name:
-                self.chats[chat_id] = chat_name
+                self.chats[chat_name] = chat_id
                 _LOGGER.debug("Parsed chat: '%s' -> %s", chat_name, chat_id)
         else:
             _LOGGER.debug("Skipping invalid chat format: %s", content)
@@ -109,6 +110,7 @@ class WhatsapperNotificationService(BaseNotificationService):
         self.hass = hass
         self._cached_targets = None
         self._cache_timestamp = None
+        #async io.createself.targets()
 
     @property
     def targets(self):
@@ -116,6 +118,9 @@ class WhatsapperNotificationService(BaseNotificationService):
         
         This property is called by Home Assistant to discover available
         notification targets. Returns a dict mapping chat_id -> chat_name.
+        
+        Note: This must be synchronous, so we return cached data or trigger
+        an async fetch in the background if cache is stale.
         """
         now = datetime.now()
         
@@ -127,47 +132,42 @@ class WhatsapperNotificationService(BaseNotificationService):
         ):
             return self._cached_targets
 
-        # Fetch and parse chat list
+        # If cache is stale or missing, trigger background refresh
+        # and return current cache (or empty dict)
+        asyncio.create_task(self._async_refresh_targets())
+        
+        return self._cached_targets or {}
+
+    async def _async_refresh_targets(self):
+        """Fetch and parse chat list asynchronously."""
         try:
+            session = async_get_clientsession(self.hass)
             url = f'http://{self.host_port}/chats'
-            response = requests.get(url, timeout=10)
-            response.raise_for_status()
             
-            # Parse HTML to extract chat list
+            async with session.get(url, timeout=10) as response:
+                response.raise_for_status()
+                html_content = await response.text()
+            
+            # Parse HTML to extract chat list (parsing is CPU-bound but fast)
             parser = ChatListParser()
-            parser.feed(response.text)
+            parser.feed(html_content)
             
             self._cached_targets = parser.chats
-            self._cache_timestamp = now
+            self._cache_timestamp = datetime.now()
             
-            _LOGGER.debug(
+            _LOGGER.info(
                 "Fetched %d chat targets from %s",
                 len(self._cached_targets),
                 url
             )
-            
-            return self._cached_targets
 
-        except requests.RequestException as e:
-            _LOGGER.error("Failed to fetch chat list from %s: %s", url, e)
-            # Return cached targets if available, even if expired
-            if self._cached_targets is not None:
-                _LOGGER.warning("Using expired cache due to fetch failure")
-                return self._cached_targets
-            # Return empty dict if no cache available
-            return {}
+        except asyncio.TimeoutError:
+            _LOGGER.error("Timeout fetching chat list from %s", url)
         except Exception as e:
-            _LOGGER.error("Error parsing chat list: %s", e)
-            return self._cached_targets or {}
+            _LOGGER.error("Failed to fetch chat list: %s", e)
 
-    def refresh_targets(self):
-        """Force refresh of chat targets by invalidating cache."""
-        self._cache_timestamp = None
-        self._cached_targets = None
-        _LOGGER.info("Chat targets cache invalidated")
-
-    def send_message(self, message="", **kwargs):
-        """Send a message to the target."""
+    async def async_send_message(self, message="", **kwargs):
+        """Send a message to the target asynchronously."""
         try:
             # Use override from notify or the one in the config
             chat_id = kwargs.get(ATTR_TARGET)
@@ -180,8 +180,13 @@ class WhatsapperNotificationService(BaseNotificationService):
                     _LOGGER.error("Empty target list provided")
                     return
                 chat_id = chat_id[0]
+            await self._async_refresh_targets()
+            tt = self._cached_targets
+            if chat_id in tt:
+                chat_id = tt[chat_id]
             
             data = kwargs.get(ATTR_DATA)
+            session = async_get_clientsession(self.hass)
 
             # Send image if all required image data is present
             if data and all(attr in data for attr in [ATTR_IMAGE, ATTR_IMAGE_TYPE, ATTR_IMAGE_NAME]):
@@ -194,8 +199,8 @@ class WhatsapperNotificationService(BaseNotificationService):
                         data[ATTR_IMAGE_NAME]
                     ]
                 }
-                response = requests.post(url, json=body, timeout=30)
-                response.raise_for_status()
+                async with session.post(url, json=body, timeout=30) as response:
+                    response.raise_for_status()
                 _LOGGER.debug("Sent media message to %s", chat_id)
                 return
 
@@ -206,11 +211,16 @@ class WhatsapperNotificationService(BaseNotificationService):
             
             url = f'http://{self.host_port}/command'
             body = {"command": "sendMessage", "params": [chat_id, msg]}
-            response = requests.post(url, json=body, timeout=30)
-            response.raise_for_status()
+            async with session.post(url, json=body, timeout=30) as response:
+                response.raise_for_status()
             _LOGGER.debug("Sent text message to %s", chat_id)
 
-        except requests.RequestException as e:
-            _LOGGER.error("HTTP request to %s failed: %s", chat_id, e)
+        except asyncio.TimeoutError:
+            _LOGGER.error("Timeout sending message to %s", chat_id)
         except Exception as e:
             _LOGGER.error("Sending to %s failed: %s", chat_id, e)
+
+    def send_message(self, message="", **kwargs):
+        """Send a message to the target (sync wrapper)."""
+        # Run the async function in the event loop
+        asyncio.create_task(self.async_send_message(message, **kwargs))

--- a/custom_components/whatsapper/notify.py
+++ b/custom_components/whatsapper/notify.py
@@ -110,14 +110,12 @@ class WhatsapperNotificationService(BaseNotificationService):
         self.hass = hass
         self._cached_targets = None
         self._cache_timestamp = None
-        #async io.createself.targets()
-
     @property
     def targets(self):
         """Return a dictionary of registered chat targets.
         
         This property is called by Home Assistant to discover available
-        notification targets. Returns a dict mapping chat_id -> chat_name.
+        notification targets. Returns a dict mapping chat_name -> chat_id.
         
         Note: This must be synchronous, so we return cached data or trigger
         an async fetch in the background if cache is stale.
@@ -134,7 +132,7 @@ class WhatsapperNotificationService(BaseNotificationService):
 
         # If cache is stale or missing, trigger background refresh
         # and return current cache (or empty dict)
-        asyncio.create_task(self._async_refresh_targets())
+        self.hass.async_create_task(self._async_refresh_targets())
         
         return self._cached_targets or {}
 

--- a/custom_components/whatsapper/notify.py
+++ b/custom_components/whatsapper/notify.py
@@ -179,9 +179,8 @@ class WhatsapperNotificationService(BaseNotificationService):
                     return
                 chat_id = chat_id[0]
             await self._async_refresh_targets()
-            tt = self._cached_targets
-            if chat_id in tt:
-                chat_id = tt[chat_id]
+            if chat_id in self._cached_targets:
+                chat_id = self._cached_targets[chat_id]
             
             data = kwargs.get(ATTR_DATA)
             session = async_get_clientsession(self.hass)
@@ -220,5 +219,5 @@ class WhatsapperNotificationService(BaseNotificationService):
 
     def send_message(self, message="", **kwargs):
         """Send a message to the target (sync wrapper)."""
-        # Run the async function in the event loop
-        asyncio.create_task(self.async_send_message(message, **kwargs))
+        # Run the async function in the Home Assistant event loop
+        self.hass.async_create_task(self.async_send_message(message, **kwargs))

--- a/custom_components/whatsapper/notify.py
+++ b/custom_components/whatsapper/notify.py
@@ -2,6 +2,8 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timedelta
+from html.parser import HTMLParser
 
 import voluptuous as vol
 
@@ -27,7 +29,59 @@ ATTR_IMAGE = "image"
 ATTR_IMAGE_TYPE = "image_type"
 ATTR_IMAGE_NAME = "image_name"
 
+# Cache configuration
+CACHE_DURATION = timedelta(minutes=15)
+
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({vol.Required(CONF_CHAT_ID): vol.Coerce(str)})
+
+
+class ChatListParser(HTMLParser):
+    """HTML parser to extract chat information from <li> elements.
+    
+    Parses format: "Chat Name: chat_id@domain"
+    Example: "Purple Tentacle: 31612345678@c.us"
+    Handles chat names containing colons.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.chats = {}
+
+    def handle_starttag(self, tag, attrs):
+        """Handle the start of HTML tags."""
+        # We'll process in handle_data, nothing to do here
+        pass
+
+    def handle_data(self, data):
+        """Parse chat data from <li> text content.
+        
+        Expected format: "Chat Name: chat_id"
+        Split on last colon to handle names with colons.
+        """
+        content = data.strip()
+        if not content:
+            return
+        
+        # Split on the last colon to separate name from ID
+        # This allows chat names to contain colons
+        if ": " in content:
+            # Find the last occurrence of ": "
+            last_colon_idx = content.rfind(": ")
+            chat_name = content[:last_colon_idx].strip()
+            chat_id = content[last_colon_idx + 2:].strip()
+            
+            # Validate chat_id format (should contain @ symbol)
+            if chat_id and "@" in chat_id and chat_name:
+                self.chats[chat_id] = chat_name
+                _LOGGER.debug("Parsed chat: '%s' -> %s", chat_name, chat_id)
+        else:
+            _LOGGER.debug("Skipping invalid chat format: %s", content)
+
+    def handle_endtag(self, tag):
+        """Handle the end of HTML tags."""
+        # Nothing to do for end tags
+        pass
+
 
 def get_service(
     hass: HomeAssistant,
@@ -44,26 +98,105 @@ def get_service(
 
     return WhatsapperNotificationService(hass, chat_id, host_port)
 
+
 class WhatsapperNotificationService(BaseNotificationService):
+    """Whatsapper notification service with chat target discovery."""
 
     def __init__(self, hass, chat_id, host_port):
         """Initialize the service."""
         self.chat_id = chat_id
         self.host_port = host_port
         self.hass = hass
+        self._cached_targets = None
+        self._cache_timestamp = None
+
+    @property
+    def targets(self):
+        """Return a dictionary of registered chat targets.
+        
+        This property is called by Home Assistant to discover available
+        notification targets. Returns a dict mapping chat_id -> chat_name.
+        """
+        now = datetime.now()
+        
+        # Return cached targets if still valid
+        if (
+            self._cached_targets is not None
+            and self._cache_timestamp is not None
+            and (now - self._cache_timestamp) < CACHE_DURATION
+        ):
+            return self._cached_targets
+
+        # Fetch and parse chat list
+        try:
+            url = f'http://{self.host_port}/chats'
+            response = requests.get(url, timeout=10)
+            response.raise_for_status()
+            
+            # Parse HTML to extract chat list
+            parser = ChatListParser()
+            parser.feed(response.text)
+            
+            self._cached_targets = parser.chats
+            self._cache_timestamp = now
+            
+            _LOGGER.debug(
+                "Fetched %d chat targets from %s",
+                len(self._cached_targets),
+                url
+            )
+            
+            return self._cached_targets
+
+        except requests.RequestException as e:
+            _LOGGER.error("Failed to fetch chat list from %s: %s", url, e)
+            # Return cached targets if available, even if expired
+            if self._cached_targets is not None:
+                _LOGGER.warning("Using expired cache due to fetch failure")
+                return self._cached_targets
+            # Return empty dict if no cache available
+            return {}
+        except Exception as e:
+            _LOGGER.error("Error parsing chat list: %s", e)
+            return self._cached_targets or {}
+
+    def refresh_targets(self):
+        """Force refresh of chat targets by invalidating cache."""
+        self._cache_timestamp = None
+        self._cached_targets = None
+        _LOGGER.info("Chat targets cache invalidated")
 
     def send_message(self, message="", **kwargs):
         """Send a message to the target."""
         try:
             # Use override from notify or the one in the config
-            chat_id = kwargs.get(ATTR_TARGET) if kwargs.get(ATTR_TARGET) else self.chat_id
+            chat_id = kwargs.get(ATTR_TARGET)
+            if not chat_id:
+                chat_id = self.chat_id
+            
+            # If target is a list, use the first one
+            if isinstance(chat_id, list):
+                if not chat_id:
+                    _LOGGER.error("Empty target list provided")
+                    return
+                chat_id = chat_id[0]
+            
             data = kwargs.get(ATTR_DATA)
 
             # Send image if all required image data is present
             if data and all(attr in data for attr in [ATTR_IMAGE, ATTR_IMAGE_TYPE, ATTR_IMAGE_NAME]):
                 url = f'http://{self.host_port}/command/media'
-                body = {"params": [chat_id, data[ATTR_IMAGE_TYPE], data[ATTR_IMAGE], data[ATTR_IMAGE_NAME]]}
-                requests.post(url, json=body)
+                body = {
+                    "params": [
+                        chat_id,
+                        data[ATTR_IMAGE_TYPE],
+                        data[ATTR_IMAGE],
+                        data[ATTR_IMAGE_NAME]
+                    ]
+                }
+                response = requests.post(url, json=body, timeout=30)
+                response.raise_for_status()
+                _LOGGER.debug("Sent media message to %s", chat_id)
                 return
 
             # Send text message
@@ -73,8 +206,11 @@ class WhatsapperNotificationService(BaseNotificationService):
             
             url = f'http://{self.host_port}/command'
             body = {"command": "sendMessage", "params": [chat_id, msg]}
-            requests.post(url, json=body)
+            response = requests.post(url, json=body, timeout=30)
+            response.raise_for_status()
+            _LOGGER.debug("Sent text message to %s", chat_id)
 
+        except requests.RequestException as e:
+            _LOGGER.error("HTTP request to %s failed: %s", chat_id, e)
         except Exception as e:
             _LOGGER.error("Sending to %s failed: %s", chat_id, e)
-


### PR DESCRIPTION
- Lookup target names to `nnn@x.us` chat_id using Whatsapper chats
- Chat_id `31612345678-0987654321@g.us`-style targets are still supported
- Refactor Whatsapper notify component to support asynchronous operations

In your automations this will allow you to do:
```
      - action: notify.whatsapp_bernard
        data:
          target: Day of the Tentacle Taskforce
          message: >
            Purple Tentacle drank toxic waste and gained intelligence and arms:
            we have to stop him from taking over the world!
```
Note the target needs to match the group name exactly!

@baldarn perhaps add this snippet to the docs?